### PR TITLE
Fix dynamic border style bug

### DIFF
--- a/src/components/SeasonalHighlights.improved.tsx
+++ b/src/components/SeasonalHighlights.improved.tsx
@@ -81,6 +81,14 @@ const SeasonalHighlights = ({ dict, lang }: SeasonalHighlightsProps) => {
     }
   ]
 
+  // Map season ids to the corresponding border color classes used in the grid
+  const borderColorClasses: Record<string, string> = {
+    spring: 'border-cherry-pink-200',
+    summer: 'border-blue-200',
+    autumn: 'border-orange-200',
+    winter: 'border-indigo-200'
+  }
+
   // Init after mount
   useEffect(() => {
     setMounted(true)
@@ -150,7 +158,13 @@ const SeasonalHighlights = ({ dict, lang }: SeasonalHighlightsProps) => {
         </div>
         
         {/* Seasons grid */}
-        <div className={`grid grid-cols-1 lg:grid-cols-3 gap-8 rounded-3xl overflow-hidden border border-${season.id === 'spring' ? 'cherry-pink' : season.id === 'summer' ? 'blue' : season.id === 'autumn' ? 'orange' : 'indigo'}-200 shadow-xl ${season.bgClass}`}>
+        {/**
+         * Tailwind can't detect dynamically generated border color classes,
+         * so we map the season ID to explicit class names.
+         */}
+        <div
+          className={`grid grid-cols-1 lg:grid-cols-3 gap-8 rounded-3xl overflow-hidden border ${borderColorClasses[season.id]} shadow-xl ${season.bgClass}`}
+        >
           {/* Season Info Column */}
           <div className={`bg-gradient-to-br ${season.color} text-white p-8 flex flex-col justify-between transition-colors duration-300`}>
             {/* Navigation dots for mobile */}


### PR DESCRIPTION
## Summary
- fix seasonal highlight border colors by mapping season IDs to Tailwind classes

## Testing
- `npx tsc -p tsconfig.json` *(fails: Failed to fetch fonts and TS errors)*
- `npm run lint` *(prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684034cb2dd483228c866a5b22ad3d4a